### PR TITLE
feat(core): Update Supported Tridecco Board Versions to Include v0.6.2

### DIFF
--- a/src/js/scripts/editor.js
+++ b/src/js/scripts/editor.js
@@ -4,6 +4,7 @@
  */
 
 const SUPPORTED_TRIDECCO_VERSIONS = [
+  '0.6.2',
   '0.6.1',
   '0.6.0',
   '0.5.1',


### PR DESCRIPTION
### Summary:

Updates the list of supported Tridecco Board library versions within the IDE to include the latest version, `0.6.2`.  This ensures users can leverage the newest features and improvements offered by the version when developing their game board configurations within the IDE.

### Changes:

- **Updated `SUPPORTED_TRIDECCO_VERSIONS` Array:**
  - Added `'0.6.2'` to the `SUPPORTED_TRIDECCO_VERSIONS` array in `src/js/scripts/editor.js`.
  - The updated list now reflects the following order (newest to oldest): `['0.6.2', '0.6.1', '0.6.0', '0.5.1', '0.5.0', '0.4.2', '0.4.1', '0.4.0', '0.3.1', '0.3.0', '0.2.3', '0.2.2', '0.2.1', '0.2.0', '0.1.1']`.